### PR TITLE
Removed call to shlex.quote to stop double quotation of the text to say

### DIFF
--- a/rhasspytts_cli_hermes/__init__.py
+++ b/rhasspytts_cli_hermes/__init__.py
@@ -88,7 +88,7 @@ class TtsHermesMqtt(HermesClient):
 
             if not self.text_on_stdin:
                 # Text as command-line arguments
-                say_command += [shlex.quote(say.text)]
+                say_command += [say.text]
 
             _LOGGER.debug(say_command)
 


### PR DESCRIPTION
It caused issues with picotts in German.

For example sending: 
Hallo Welt
would end up as: 
'Hallo Welt'  
in argv[5] of pico2wave.  pico2wave would then speak it as "Hallo Welt Apostrophe"    it would read out the ' at the end.

From the subprocess.Popen documentation:

> args is required for all calls and should be a string, or a sequence of program arguments. Providing a sequence of arguments is generally preferred, as it allows the module to take care of any required escaping and quoting of arguments (e.g. to permit spaces in file names).

and

> Unlike some other popen functions, this implementation will never implicitly call a system shell. This means that all characters, including shell metacharacters, can safely be passed to child processes. If the shell is invoked explicitly, via shell=True, it is the application’s responsibility to ensure that all whitespace and metacharacters are quoted appropriately to avoid shell injection vulnerabilities.

shell=False is used here.